### PR TITLE
Add loading display functionality

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -15,6 +15,7 @@ class App extends Component {
       characters: [],
       scroll: '',
       error: '',
+      isLoading: true,
       user: {
         name: '',
         quote: '',
@@ -29,23 +30,22 @@ class App extends Component {
 
   componentDidMount() {
     getFilms()
-      .then(data => this.setState({ movies: data.results }))
+      .then(data => this.setState({ movies: data.results, isLoading: false }))
       .catch(err => {
         console.log(err);
         this.setState({ error: err.message})
       })
   }
 
-  setScroll = (movie) => {
-    this.setState({ scroll: movie.opening_crawl })
+  setScrollAndLoading = (movie) => {
+    this.setState({ scroll: movie.opening_crawl, isLoading: true, characters: [] })
   }
-
 
   fetchHandler = (episode) => {
     const selectedMov = this.state.movies.find(movie => movie.episode_id === episode)
     const tenCharacters = selectedMov.characters.slice(0, 10);
 
-    this.setScroll(selectedMov);
+    this.setScrollAndLoading(selectedMov);
 
     const fetchCharData = () => {
       const fetchedCharacters = tenCharacters.map(character => {
@@ -59,7 +59,7 @@ class App extends Component {
           .then(charData => getNestedData(charData))
       });
       Promise.all(fetchedCharacters)
-        .then(data => this.setState({ characters: data }))
+        .then(data => this.setState({ characters: data, isLoading: false }))
         .catch(err => {
           console.log(err);
           this.setState({ error: err.message})
@@ -141,12 +141,14 @@ class App extends Component {
             data={this.state.movies}
             fetchHandler={this.fetchHandler}
             isMovies={true}
+            isLoading={this.state.isLoading}
           />)}
         } />
         <Route path='/movies/:movie_id' render={ ({ match }) => {
           return(<DisplayContainer
             scroll={this.state.scroll}
             data={this.state.characters}
+            isLoading={this.state.isLoading}
             />)}
         } />
       </div>

--- a/src/components/App/App.test.js
+++ b/src/components/App/App.test.js
@@ -52,7 +52,7 @@ describe('App', () => {
     expect(wrapper.state('user')).toEqual(expected);
   })
 
-  it('should update state when setScroll is invoked', () => {
+  it('should update state when setScrollAndLoading is invoked', () => {
     const mockMovie = {
     "title": "The Empire Strikes Back",
     "episode_id": 5,
@@ -71,7 +71,7 @@ describe('App', () => {
     };
     const expected = "Impressive opening starwars crawl";
 
-    wrapper.instance().setScroll(mockMovie);
+    wrapper.instance().setScrollAndLoading(mockMovie);
 
     expect(wrapper.state('scroll')).toEqual(expected);
   })

--- a/src/components/DisplayContainer/DisplayContainer.js
+++ b/src/components/DisplayContainer/DisplayContainer.js
@@ -4,7 +4,7 @@ import MovieCard from '../MovieCard/MovieCard';
 import CharacterCard from '../CharacterCard/CharacterCard';
 import PropTypes from 'prop-types';
 
-const DisplayContainer = ( {data, fetchHandler, isMovies, scroll} ) => {
+const DisplayContainer = ( {data, fetchHandler, isMovies, scroll, isLoading} ) => {
   const cards = data.map(item => {
     if (isMovies) {
       return <MovieCard
@@ -29,6 +29,8 @@ const DisplayContainer = ( {data, fetchHandler, isMovies, scroll} ) => {
   return (
 
     <main className='display-container' key=''>
+      {isLoading && <h2 className='loadingDisplay'>
+          Be Patient One Must....What You Seek Display Soon Will</h2>}
       {scroll && <div className="scroll-container">
         <div className="scroll">{scroll}</div>
       </div>}

--- a/src/components/DisplayContainer/DisplayContainer.scss
+++ b/src/components/DisplayContainer/DisplayContainer.scss
@@ -21,3 +21,9 @@
   }
 }
 
+.loadingDisplay {
+    text-align: center;
+    font-size: 2em;
+    color: $accent-color;
+    margin: 20px;
+}


### PR DESCRIPTION
### What's this PR do?  
- Draft PR (after submission deadline but wanted to set these up)
- Implements error handling/display and loading handling/display

### Where should the reviewer start? 
- Updates in App allows us to display an error if a fetch fails or returns `ok: false`
- Updates across App and Display Container allow us to display a loading indicator.  Currently this is just text but can be updated to an animation or loading spinner in future iterations

### How should this be manually tested? 
- To test Loading indicator: simply pull down this branch and navigate through the app.
- To test Error display: You can modify the initial fetch URL to cause the .catch() to run and see the error display

### Screenshots (if appropriate)

#### Loading Indicator While Character Cards Are Fetching

![SWAPI-loading-indicator](https://user-images.githubusercontent.com/48163945/70581545-bb415a00-1b74-11ea-8287-1ff21c6039ff.png)

#### Error Display When Fetch Fails 
(Issue will be opened to remove loading indicator if error occurs)

![SWAPI-error-display-shows-bug](https://user-images.githubusercontent.com/48163945/70581638-11160200-1b75-11ea-817e-60de1820a5e1.png)
